### PR TITLE
fix: serve robots.txt statically for Googlebot

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       crawlLinks: true,
-      routes: ['/', ...prerenderRoutes],
+      routes: ['/', '/sitemap.xml', ...prerenderRoutes],
     },
   },
 
@@ -72,7 +72,6 @@ export default defineNuxtConfig({
     '@nuxtjs/tailwindcss',
     '@nuxtjs/color-mode',
     '@nuxtjs/sitemap',
-    '@nuxtjs/robots',
     '@nuxtjs/web-vitals',
   ],
 
@@ -107,17 +106,6 @@ export default defineNuxtConfig({
     sources: [
       '/api/__sitemap__/urls'
     ]
-  },
-
-  robots: {
-    groups: [
-      {
-        userAgent: '*',
-        allow: ['/', '/og/'],
-        disallow: ['/api/'],
-      },
-    ],
-    sitemap: 'https://artisan.eplus.dev/sitemap.xml',
   },
 
   colorMode: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+
+Sitemap: https://artisan.eplus.dev/sitemap.xml


### PR DESCRIPTION
## Summary
- add a physical `public/robots.txt` so static hosting can always serve `/robots.txt` without relying on a Nitro server route
- remove the runtime `@nuxtjs/robots` module/config to avoid duplicate ownership of `/robots.txt`
- explicitly prerender `/sitemap.xml`

## Why
Google Search Console reports `Failed: Robots.txt unreachable`. The current deployment is prerender/static-oriented, while robots.txt was generated by a Nuxt server module. Serving it directly from `public/` removes that runtime dependency and makes the file available as a normal static asset.

## Expected result
`https://artisan.eplus.dev/robots.txt` should return HTTP 200 with:

```txt
User-agent: *
Allow: /
Disallow: /api/

Sitemap: https://artisan.eplus.dev/sitemap.xml
```

After deployment, retest the URL in Google Search Console before requesting indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sitemap URL to the prerendered site output.
  * Added crawler directives that allow general site indexing while excluding API routes.
  * Declared the sitemap location for search engine crawlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->